### PR TITLE
add psu input voltage and current

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -58,6 +58,9 @@ PSU_INFO_VOLTAGE_MIN_TH_FIELD = 'voltage_min_threshold'
 PSU_INFO_CURRENT_FIELD = 'current'
 PSU_INFO_POWER_FIELD = 'power'
 PSU_INFO_FRU_FIELD = 'is_replaceable'
+PSU_INFO_IN_VOLTAGE_FIELD = 'input_voltage'
+PSU_INFO_IN_CURRENT_FIELD = 'input_current'
+PSU_INFO_POWER_MAX_FIELD = 'max_power'
 
 PHYSICAL_ENTITY_INFO_TABLE = 'PHYSICAL_ENTITY_INFO'
 
@@ -455,6 +458,9 @@ class DaemonPsud(daemon_base.DaemonBase):
         current = NOT_AVAILABLE
         power = NOT_AVAILABLE
         is_replaceable = try_get(psu.is_replaceable, False)
+        in_voltage = NOT_AVAILABLE
+        in_current = NOT_AVAILABLE
+        max_power = NOT_AVAILABLE
         if presence:
             power_good = _wrapper_get_psu_status(index)
             voltage = try_get(psu.get_voltage, NOT_AVAILABLE)
@@ -464,6 +470,9 @@ class DaemonPsud(daemon_base.DaemonBase):
             temperature_threshold = try_get(psu.get_temperature_high_threshold, NOT_AVAILABLE)
             current = try_get(psu.get_current, NOT_AVAILABLE)
             power = try_get(psu.get_power, NOT_AVAILABLE)
+            in_current = try_get(psu.get_input_current, NOT_AVAILABLE)
+            in_voltage = try_get(psu.get_input_voltage, NOT_AVAILABLE)
+            max_power = try_get(psu.get_maximum_supplied_power, NOT_AVAILABLE)
 
         if index not in self.psu_status_dict:
             self.psu_status_dict[index] = PsuStatus(self, psu, index)
@@ -524,6 +533,9 @@ class DaemonPsud(daemon_base.DaemonBase):
              (PSU_INFO_CURRENT_FIELD, str(current)),
              (PSU_INFO_POWER_FIELD, str(power)),
              (PSU_INFO_FRU_FIELD, str(is_replaceable)),
+             (PSU_INFO_IN_CURRENT_FIELD, str(in_current)),
+             (PSU_INFO_IN_VOLTAGE_FIELD, str(in_voltage)),
+             (PSU_INFO_POWER_MAX_FIELD, str(max_power)),
              ])
         self.psu_tbl.set(name, fvs)
 

--- a/sonic-psud/tests/mock_platform.py
+++ b/sonic-psud/tests/mock_platform.py
@@ -282,7 +282,9 @@ class MockPsu(psu_base.PsuBase):
                  temp_high_th=50.0,
                  voltage_low_th=11.0,
                  voltage_high_th=13.0,
-                 replaceable=True):
+                 replaceable=True,
+                 in_current=0.72,
+                 in_voltage=220.25):
         super(MockPsu, self).__init__()
         self._name = name
         self._presence = presence
@@ -301,6 +303,9 @@ class MockPsu(psu_base.PsuBase):
         self._voltage_low_th = voltage_low_th
         self._voltage_high_th = voltage_high_th
         self._status_led_color = self.STATUS_LED_COLOR_OFF
+        self._in_voltage = in_voltage
+        self._in_current = in_current
+        self._max_supplied_power = 'N/A'
 
     def get_voltage(self):
         return self._voltage
@@ -381,3 +386,9 @@ class MockPsu(psu_base.PsuBase):
 
     def is_replaceable(self):
         return self._replaceable
+
+    def get_input_current(self):
+        return self._in_current
+
+    def get_input_voltage(self):
+        return self._in_voltage

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -165,6 +165,9 @@ class TestDaemonPsud(object):
              (psud.PSU_INFO_CURRENT_FIELD, '8.0'),
              (psud.PSU_INFO_POWER_FIELD, '100.0'),
              (psud.PSU_INFO_FRU_FIELD, 'True'),
+             (psud.PSU_INFO_IN_VOLTAGE_FIELD, '220.25'),
+             (psud.PSU_INFO_IN_CURRENT_FIELD, '0.72'),
+             (psud.PSU_INFO_POWER_MAX_FIELD, 'N/A'),
              ])
 
         daemon_psud = psud.DaemonPsud(SYSLOG_IDENTIFIER)


### PR DESCRIPTION
Signed-off-by: orfar1994 <orfar1994@gmail.com>

Add PSU input voltage, input current and max power to the PSU table in the STATE DB

#### Description
psud would collect input voltage, input current and max power (capacity) of the PSU. 
till now, it collect the output voltage and current.

#### Motivation and Context
more information about the PSU. 

#### How Has This Been Tested?
unitests, on switch.

#### Additional Information (Optional)
